### PR TITLE
Fix example to use fork-secrets-friendly target

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ So far it requires additional step - checkout base branch as well.
 ## Usage example
 
 ```yml
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   map-diff:


### PR DESCRIPTION
With `pull_request_target` cloudinary secrets will be available to forks as well, which simplifies things.