### PR TITLE
Fix documentation to check out correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
       - name: Create DIFF
         id: diff
         uses: Delwing/mudlet-map-diff-action@v2


### PR DESCRIPTION
With the default arguments, the `pull_request_target` trigger checks out the `base` version instead of the needed `head` version.